### PR TITLE
Support to run tests on Node.js

### DIFF
--- a/modules/js/CMakeLists.txt
+++ b/modules/js/CMakeLists.txt
@@ -39,7 +39,8 @@ set(OCV_JS_PATH "${OpenCV_BINARY_DIR}/bin/${OPENCV_JS}")
 add_custom_command(
    OUTPUT ${OCV_JS_PATH}
    COMMAND ${PYTHON_DEFAULT_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/src/make_umd.py" ${MODULE_JS_PATH} "${OCV_JS_PATH}"
-   DEPENDS ${the_module})
+   DEPENDS ${the_module}
+   DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/make_umd.py")
 
 add_custom_target(${PROJECT_NAME}_final ALL
                   DEPENDS ${OCV_JS_PATH})

--- a/modules/js/src/make_umd.py
+++ b/modules/js/src/make_umd.py
@@ -26,6 +26,8 @@ def make_umd(opencvjs, cvjs):
   }
 }(this, function () {
   %s
+  if (typeof Module === 'undefined')
+    Module = {};
   return cv(Module);
 }));
     """ % (content)).lstrip())

--- a/modules/js/test/test_commons.js
+++ b/modules/js/test/test_commons.js
@@ -86,3 +86,5 @@ var Commons = {
 	// }
 	//
 };
+
+if (typeof module !== 'undefined' && module.exports) exports.Commons = Commons;

--- a/modules/js/test/test_features2d.js
+++ b/modules/js/test/test_features2d.js
@@ -30,6 +30,10 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /////////////////////////////////////////////////////////////////////////////*/
+if (typeof module !== 'undefined' && module.exports) {
+    // The envrionment is Node.js
+    var cv = require('./test_node.js');
+}
 
 QUnit.module( "Feature2D", {});
 QUnit.test( "Test Feature detection/extraction", function(assert) {

--- a/modules/js/test/test_imgproc.js
+++ b/modules/js/test/test_imgproc.js
@@ -30,9 +30,10 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /////////////////////////////////////////////////////////////////////////////*/
-
-
-
+if (typeof module !== 'undefined' && module.exports) {
+    // The envrionment is Node.js
+    var cv = require('./test_node.js');
+}
 
 QUnit.module("Image Processing", {});
 
@@ -837,7 +838,7 @@ QUnit.test("test_filter", function(assert) {
       assert.equal(size.get(0), 4);
       assert.equal(size.get(1), 4);
       assert.deepEqualWithTolerance(inv3.data32f(), expected3, 0.0001);
-      console.log(inv3.data32f());
+      //console.log(inv3.data32f());
 
 
       cv.invert(mat3, inv3, 1);

--- a/modules/js/test/test_io.js
+++ b/modules/js/test/test_io.js
@@ -30,6 +30,11 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /////////////////////////////////////////////////////////////////////////////*/
+if (typeof module !== 'undefined' && module.exports) {
+    // The envrionment is Node.js
+    var cv = require('./test_node.js');
+    var Commons = require('./test_commons.js').Commons;
+}
 
 QUnit.module ("IO", {});
 QUnit.test("Test IO", function(assert) {
@@ -83,7 +88,7 @@ QUnit.test("Test IO", function(assert) {
         let mat = new cv.Mat([50, 50], cv.CV_8UC4);
 
         Commons.createAlphaMat(mat);
-        Commons.showImage(mat);
+        if(typeof window !=="undefined") Commons.showImage(mat);
 
         mat.delete();
     }

--- a/modules/js/test/test_mat.js
+++ b/modules/js/test/test_mat.js
@@ -30,6 +30,10 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /////////////////////////////////////////////////////////////////////////////*/
+if (typeof module !== 'undefined' && module.exports) {
+    // The envrionment is Node.js
+    var cv = require('./opencv.js');
+}
 
 QUnit.module( "Core", {});
 

--- a/modules/js/test/test_ml.js
+++ b/modules/js/test/test_ml.js
@@ -30,6 +30,10 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /////////////////////////////////////////////////////////////////////////////*/
+if (typeof module !== 'undefined' && module.exports) {
+    // The envrionment is Node.js
+    var cv = require('./opencv.js');
+}
 
 QUnit.module ("ML", {});
 QUnit.test("Stat Models", function(assert) {

--- a/modules/js/test/test_objdetect.js
+++ b/modules/js/test/test_objdetect.js
@@ -30,6 +30,13 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /////////////////////////////////////////////////////////////////////////////*/
+if (typeof module !== 'undefined' && module.exports) {
+    // The envrionment is Node.js
+    var cv = require('./opencv.js');
+    cv.FS_createLazyFile('/', 'haarcascade_eye.xml', 'data/haarcascade_eye.xml', true, false);
+    cv.FS_createLazyFile('/', 'haarcascade_frontalface_default.xml', 'data/haarcascade_frontalface_default.xml', true, false);
+    cv.FS_createLazyFile('/', 'hogcascade_pedestrians.xml', 'data/hogcascade_pedestrians.xml', true, false);
+}
 
 QUnit.module ("Object Detection", {});
 QUnit.test("Cascade classification", function(assert) {

--- a/modules/js/test/test_photo.js
+++ b/modules/js/test/test_photo.js
@@ -30,6 +30,10 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /////////////////////////////////////////////////////////////////////////////*/
+if (typeof module !== 'undefined' && module.exports) {
+    // The envrionment is Node.js
+    var cv = require('./opencv.js');
+}
 
 QUnit.module ("Computational Photography", {});
 QUnit.test("Test Inpinting", function(assert) {

--- a/modules/js/test/test_shape.js
+++ b/modules/js/test/test_shape.js
@@ -30,6 +30,10 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /////////////////////////////////////////////////////////////////////////////*/
+if (typeof module !== 'undefined' && module.exports) {
+    // The envrionment is Node.js
+    var cv = require('./opencv.js');
+}
 
 QUnit.module ("Shapes", {});
 QUnit.test("Test transformers", function(assert) {

--- a/modules/js/test/test_utils.js
+++ b/modules/js/test/test_utils.js
@@ -30,6 +30,10 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /////////////////////////////////////////////////////////////////////////////*/
+if (typeof module !== 'undefined' && module.exports) {
+    // The envrionment is Node.js
+    var cv = require('./opencv.js');
+}
 QUnit.module ("Utils", {});
 QUnit.test("Test vectors", function(assert) {
 	let pointVector = new cv.PointVector();

--- a/modules/js/test/test_video.js
+++ b/modules/js/test/test_video.js
@@ -30,6 +30,10 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /////////////////////////////////////////////////////////////////////////////*/
+if (typeof module !== 'undefined' && module.exports) {
+    // The envrionment is Node.js
+    var cv = require('./opencv.js');
+}
 
 QUnit.module ("Video", {});
 //QUnit.test("Tracking", function(assert) {

--- a/modules/js/test/tests.js
+++ b/modules/js/test/tests.js
@@ -1,0 +1,11 @@
+var testrunner = require('qunit');
+testrunner.options.maxBlockDuration = 20000; // cause opencv_js.js need time to load
+
+
+testrunner.run({
+    code: 'opencv.js',
+    tests: ['test_mat.js', 'test_utils.js', 'test_imgproc.js', 'test_photo.js',
+            'test_objdetect.js', 'test_shape.js', 'test_ml.js', 'test_io.js', 'test_video.js' 
+             ]}, function(err, report) {
+    console.log(report.failed + ' failed, ' + report.passed + ' passed');
+});


### PR DESCRIPTION
Fix tests to import cv Module when runtime is node.
Add tests.js to use qunit to auto run tests.
Modify umd wrapper to support Module is not defined.

Usage:
node tests.js

