### PR TITLE
Add js_tutorials folder and a intro page of opencv.js

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,7 +251,7 @@ OCV_OPTION(WITH_LAPACK         "Include Lapack library support"              ON 
 OCV_OPTION(BUILD_SHARED_LIBS        "Build shared libraries (.dll/.so) instead of static ones (.lib/.a)" NOT (ANDROID OR APPLE_FRAMEWORK) IF NOT EMSCRIPTEN )
 OCV_OPTION(BUILD_opencv_apps        "Build utility applications (used for example to train classifiers)" (NOT ANDROID AND NOT WINRT) IF (NOT APPLE_FRAMEWORK AND NOT EMSCRIPTEN) )
 OCV_OPTION(BUILD_ANDROID_EXAMPLES   "Build examples for Android platform"         ON  IF ANDROID )
-OCV_OPTION(BUILD_DOCS               "Create build rules for OpenCV Documentation" ON  IF (NOT WINRT OR APPLE_FRAMEWORK AND NOT EMSCRIPTEN))
+OCV_OPTION(BUILD_DOCS               "Create build rules for OpenCV Documentation" ON  IF (NOT WINRT OR APPLE_FRAMEWORK))
 OCV_OPTION(BUILD_EXAMPLES           "Build all examples"                          OFF )
 OCV_OPTION(BUILD_PACKAGE            "Enables 'make package_source' command"       ON  IF (NOT WINRT AND NOT EMSCRIPTEN))
 OCV_OPTION(BUILD_PERF_TESTS         "Build performance tests"                     ON  IF (NOT APPLE_FRAMEWORK AND NOT EMSCRIPTEN) )

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -33,7 +33,7 @@ endif(HAVE_DOC_GENERATOR)
 
 if(BUILD_DOCS AND DOXYGEN_FOUND)
   # not documented modules list
-  list(APPEND blacklist "ts" "java" "python2" "python3" "world" "contrib_world")
+  list(APPEND blacklist "ts" "java" "python2" "python3" "js" "world" "contrib_world")
   unset(CMAKE_DOXYGEN_TUTORIAL_CONTRIB_ROOT)
 
   # gathering headers
@@ -134,11 +134,12 @@ if(BUILD_DOCS AND DOXYGEN_FOUND)
   set(faqfile "${CMAKE_CURRENT_SOURCE_DIR}/faq.markdown")
   set(tutorial_path "${CMAKE_CURRENT_SOURCE_DIR}/tutorials")
   set(tutorial_py_path "${CMAKE_CURRENT_SOURCE_DIR}/py_tutorials")
+  set(tutorial_js_path "${CMAKE_CURRENT_SOURCE_DIR}/js_tutorials")
   set(example_path "${CMAKE_SOURCE_DIR}/samples")
 
   # set export variables
-  string(REPLACE ";" " \\\n" CMAKE_DOXYGEN_INPUT_LIST "${rootfile} ; ${faqfile} ; ${paths_include} ; ${paths_hal_interface} ; ${paths_doc} ; ${tutorial_path} ; ${tutorial_py_path} ; ${paths_tutorial} ; ${tutorial_contrib_root}")
-  string(REPLACE ";" " \\\n" CMAKE_DOXYGEN_IMAGE_PATH "${paths_doc} ; ${tutorial_path} ; ${tutorial_py_path} ; ${paths_tutorial}")
+  string(REPLACE ";" " \\\n" CMAKE_DOXYGEN_INPUT_LIST "${rootfile} ; ${faqfile} ; ${paths_include} ; ${paths_hal_interface} ; ${paths_doc} ; ${tutorial_path} ; ${tutorial_py_path} ; ${tutorial_js_path} ; ${paths_tutorial} ; ${tutorial_contrib_root}")
+  string(REPLACE ";" " \\\n" CMAKE_DOXYGEN_IMAGE_PATH "${paths_doc} ; ${tutorial_path} ; ${tutorial_py_path} ; ${tutorial_js_path} ; ${paths_tutorial}")
   # TODO: remove paths_doc from EXAMPLE_PATH after face module tutorials/samples moved to separate folders
   string(REPLACE ";" " \\\n" CMAKE_DOXYGEN_EXAMPLE_PATH  "${example_path} ; ${paths_doc} ; ${paths_sample}")
   set(CMAKE_DOXYGEN_LAYOUT "${CMAKE_CURRENT_SOURCE_DIR}/DoxygenLayout.xml")

--- a/doc/js_tutorials/js_setup/js_intro/js_intro.markdown
+++ b/doc/js_tutorials/js_setup/js_intro/js_intro.markdown
@@ -1,0 +1,25 @@
+Introduction to OpenCV-JavaScript Tutorials {#tutorial_js_intro}
+=======================================
+
+OpenCV
+------
+
+OpenCV was started at Intel in 1999 by **Gary Bradsky**, and the first release came out in 2000.
+**Vadim Pisarevsky** joined Gary Bradsky to manage Intel's Russian software OpenCV team. In 2005,
+OpenCV was used on Stanley, the vehicle that won the 2005 DARPA Grand Challenge. Later, its active
+development continued under the support of Willow Garage with Gary Bradsky and Vadim Pisarevsky
+leading the project. OpenCV now supports a multitude of algorithms related to Computer Vision and
+Machine Learning and is expanding day by day.
+
+OpenCV supports a wide variety of programming languages such as C++, Python, Java, etc., and is
+available on different platforms including Windows, Linux, OS X, Android, and iOS. Interfaces for
+high-speed GPU operations based on CUDA and OpenCL are also under active development.
+
+OpenCV-JavaScript is the JavaScript API for OpenCV, combining the best qualities of the OpenCV C++ API and
+the JavaScript language.
+
+OpenCV-JavaScript
+-------------
+
+OpenCV-JavaScript is a library of JavaScript bindings designed to solve computer vision problems.
+(This page is a imitation of OpenCV-Python tutorial and need to be updated )

--- a/doc/js_tutorials/js_setup/js_setup_in_ubuntu/js_setup_in_ubuntu.markdown
+++ b/doc/js_tutorials/js_setup/js_setup_in_ubuntu/js_setup_in_ubuntu.markdown
@@ -1,0 +1,77 @@
+Install OpenCV-JavaScript in Ubuntu {#tutorial_js_setup_in_ubuntu}
+===============================
+
+
+Installing Dependencies
+-----------------------------
+
+First we will install some dependencies.
+
+### Emscripten
+Install emscripten. You can obtain emscripten by using [Emscripten SDK](https://kripken.github.io/emscripten-site/docs/getting_started/downloads.html).
+@code
+./emsdk update
+./emsdk install sdk-master-64bit --shallow
+./emsdk activate sdk-master-64bit
+source ./emsdk_env.sh
+@endcode
+Patch Emscripten & Rebuild. //todo
+@code
+patch -p1 < PATH/TO/patch_emscripten_master.diff
+@endcode
+Rebuild emscripten
+@code
+./emsdk install sdk-master-64bit --shallow
+@endcode
+
+### Node.js
+//todo
+
+### Downloading OpenCV
+You can download the latest release of OpenCV from [sourceforge
+site](http://sourceforge.net/projects/opencvlibrary/). Then extract the folder.
+
+Or you can download latest source from OpenCV's github repo. (If you want to contribute to OpenCV,
+choose this. It always keeps your OpenCV up-to-date). For that, you need to install **Git** first.
+@code{.sh}
+apt-get install git
+git clone https://github.com/opencv/opencv.git
+@endcode
+It will create a folder OpenCV in home directory (or the directory you specify). The cloning may
+take some time depending upon your internet connection.
+
+Now open a terminal window and navigate to the downloaded OpenCV folder. Create a new build folder
+and navigate to it.
+@code{.sh}
+mkdir build_js
+cd build_js
+@endcode
+### Configuring and Building
+Build
+@code{.sh}
+cd opencv
+mkdir build_js
+cd build_js
+cmake -D CMAKE_TOOLCHAIN_FILE=${EMSCRIPTEN}/cmake/Modules/Platform/Emscripten.cmake -D CMAKE_BUILD_TYPE=Debug -D CMAKE_INSTALL_PREFIX=/usr/local ..
+make -j7
+@endcode
+Test in browser
+@code{.sh}
+cd bin
+python server.py
+@endcode
+
+Launch browser to `http://localhost:8000`.
+
+Tests include:
+* tests.html
+* features_2d.html
+* img_proc.html
+* face_detect.html
+
+Test in Node.js
+@code{.sh}
+cd bin
+npm install
+node tests.js
+@endcode

--- a/doc/js_tutorials/js_setup/js_table_of_contents_setup.markdown
+++ b/doc/js_tutorials/js_setup/js_table_of_contents_setup.markdown
@@ -1,0 +1,12 @@
+Introduction to OpenCV {#tutorial_js_table_of_contents_setup}
+======================
+
+-   @subpage tutorial_js_intro
+
+    Getting Started with
+    OpenCV-JavaScript
+
+-   @subpage tutorial_js_setup_in_ubuntu
+
+    Set Up
+    OpenCV-JavaScript in Ubuntu

--- a/doc/js_tutorials/js_tutorials.markdown
+++ b/doc/js_tutorials/js_tutorials.markdown
@@ -1,0 +1,6 @@
+OpenCV-JavaScript Tutorials {#tutorial_js_root}
+=======================
+
+-   @subpage tutorial_js_table_of_contents_setup
+
+    Learn how to build OpenCV-JavaScript on your computer!

--- a/doc/root.markdown.in
+++ b/doc/root.markdown.in
@@ -4,6 +4,7 @@ OpenCV modules {#mainpage}
 - @ref intro
 - @ref tutorial_root
 - @ref tutorial_py_root
+- @ref tutorial_js_root
 @CMAKE_DOXYGEN_TUTORIAL_CONTRIB_ROOT@
 - @ref faq
 - @ref citelist


### PR DESCRIPTION
Enable BUILD_DOCS in CMakeLists.txt.
Add new folder of js_tutorials in folder opencv/doc.
Imitate the tutorials of OpenCV-Python to create a intro page of opencv.js and a setup guide