### PR TITLE
Revert "Expose polylines for video analysis tutorial"

### DIFF
--- a/modules/js/src/embindgen.py
+++ b/modules/js/src/embindgen.py
@@ -73,7 +73,7 @@ white_list = {'': ['absdiff', 'add', 'addWeighted', 'bitwise_and', 'bitwise_not'
                    'findTransformECC', 'meanShift', 'getRotationMatrix2D', 'getPerspectiveTransform', 'filter2D', 'morphologyEx',\
                    'getStructuringElement', 'convertScaleAbs', 'isContourConvex', 'minAreaRect', 'minEnclosingCircle', 'fitLine',\
                    'minMaxLoc', 'convexityDefects', 'pointPolygonTest', 'matchShapes', 'createCLAHE', 'dft', 'getOptimalDFTSize',\
-                   'HoughLines', 'HoughLinesP', 'HoughCircles', 'polylines'],
+                   'HoughLines', 'HoughLinesP', 'HoughCircles'],
               'HOGDescriptor': ['load', 'HOGDescriptor', 'getDefaultPeopleDetector', 'getDaimlerPeopleDetector', 'setSVMDetector', 'detectMultiScale'],
               'CascadeClassifier': ['load', 'detectMultiScale2', 'CascadeClassifier', 'detectMultiScale3', 'empty', 'detectMultiScale'],
               'BackgroundSubtractorMOG2': ['BackgroundSubtractorMOG2', 'apply'],


### PR DESCRIPTION
This reverts commit 3ce7615652e510d30e3c0014706ac38c98883189.

Fix #121
