### PR TITLE
Update tutorials after 8/2 sync meeting

### DIFF
--- a/doc/js_tutorials/js_gui/js_table_of_contents_gui.markdown
+++ b/doc/js_tutorials/js_gui/js_table_of_contents_gui.markdown
@@ -1,4 +1,4 @@
-Gui Features in OpenCV-JavaScript {#tutorial_js_table_of_contents_gui}
+Gui Features {#tutorial_js_table_of_contents_gui}
 ======================
 
 -   @subpage tutorial_js_image_display

--- a/doc/js_tutorials/js_imgproc/js_table_of_contents_imgproc.markdown
+++ b/doc/js_tutorials/js_imgproc/js_table_of_contents_imgproc.markdown
@@ -1,4 +1,4 @@
-Image Processing in OpenCV {#tutorial_js_table_of_contents_imgproc}
+Image Processing {#tutorial_js_table_of_contents_imgproc}
 ==========================
 
 -   @subpage tutorial_js_colorspaces

--- a/doc/js_tutorials/js_setup/js_intro/js_intro.markdown
+++ b/doc/js_tutorials/js_setup/js_intro/js_intro.markdown
@@ -1,4 +1,4 @@
-Introduction to OpenCV-JavaScript and Tutorials {#tutorial_js_intro}
+Introduction to OpenCV.js and Tutorials {#tutorial_js_intro}
 =======================================
 
 OpenCV
@@ -15,39 +15,39 @@ OpenCV supports a wide variety of programming languages such as C++, Python, Jav
 and is available on different platforms including Windows, Linux, OS X, Android, iOS and Web Browsers.
 Interfaces for high-speed GPU operations based on CUDA and OpenCL are also under active development.
 
-OpenCV-JavaScript
+OpenCV.js
 -------------
 
 Web is the most ubiquitous open computing platform. With HTML5 standards get implemented in every browser, web applications are able to render online video with HTML5 video tag, capture the video from web camera via WebRTC API and access each pixel of video frame via canvas API. With these huge multimedia contents available on web, web developers are in need of wide array of image and vision processing algorithms in JavaScript to build innovative applications, such as facial detection in live WebRTC streaming. And this requirement is even more essential for emerging usages on web, such as Web Virtual Reality and Augmented Reality (WebVR). All these use cases demand efficient implementations of computer-intensive vision kernels on web.
 
 [Emscripten](http://kripken.github.io/emscripten-site) is an LLVM-to-JavaScript compiler. It takes LLVM bitcode - which can be generated from C/C++, using clang, and compiles that into a subset of JavaScript - asm.js. asm.js is an intermediate programming language designed to allow computer software written in languages such as C to be run as web applications while maintaining performance characteristics considerably better than standard JavaScript, the typical language used for such applications. The performance of asm.js is improved by limiting language features of JavaScript to those amenable to ahead-of-time optimization and other performance improvements.
 
-OpenCV-JavaScript is the JavaScript API binding for OpenCV. It allows emerging web applications with multimedia processing to benefit from the wide variety of vision functions available in OpenCV. OpenCV-JavaScript leverages Emscripten, compiles OpenCV functions' implementation into asm.js and exposes JavaScript APIs for web applications use. The future version will support WebAssembly and other acceleration APIs available on Web.
+OpenCV.js is the JavaScript binding for a subset of OpenCV. It allows emerging web applications with multimedia processing to benefit from the wide variety of vision functions available in OpenCV. OpenCV.js leverages Emscripten, compiles OpenCV functions' implementation into asm.js and exposes JavaScript APIs for web applications use. The future version will support WebAssembly and other acceleration APIs available on Web.
 
-OpenCV-JavaScript is based on [OpenCV.js](https://github.com/ucisysarch/opencvjs), the pioneer project initiated in Parallel Architectures and Systems Group at University of California Irvine.
+OpenCV.js was initiated in Parallel Architectures and Systems Group at University of California Irvine (UCI), funded by Intel Corportation. OpenCV.js got improved and integrated into OpenCV project as part of Google Summer of Code 2017 projects. 
 
-
-OpenCV-JavaScript Tutorials
+OpenCV.js Tutorials
 -----------------------
 
 OpenCV introduces a new set of tutorials which will guide you through various functions available in
-OpenCV-JavaScript. **This guide is mainly focused on OpenCV 3.x version**.
+OpenCV.js. **This guide is mainly focused on OpenCV 3.x version**.
 
-The purposes of OpenCV-JavaScript tutorials include
+The purposes of OpenCV.js tutorials include
 -# Help with adaptability of OpenCV in web development
 -# Help the web community, developers and computer vision researcher to interactively access variety of web based OpenCV examples to help them understand specific vision algorithm.
 
-As OpenCV-JavaScript is able to run directly inside browser, the OpenCV-JavaScript tutorial web pages are intuitive and interactive. For example, by using WebRTC API and evaluation of JavaScript code, it would allow developers to change the parameters of CV functions and even do live CV coding on web pages to see the results in real time.
+As OpenCV.js is able to run directly inside browser, the OpenCV.js tutorial web pages are intuitive and interactive. For example, by using WebRTC API and evaluation of JavaScript code, it would allow developers to change the parameters of CV functions and even do live CV coding on web pages to see the results in real time.
 
 Prior knowledge of JavaScript and web application development is recommended as they won't be covered in this guide.
 
 Contributors
 ------------
 
-Below is the list of contributors of OpenCV-JavaScript bindings and tutorials.
+Below is the list of contributors of OpenCV.js bindings and tutorials.
 
 -#  Sajjad Taheri (Google Summer of Code 2017 mentor, University of California, Irvine)
 -#  Congxiang Pan (Google Summer of Code 2017 intern, Shanghai Jiao Tong University)
+-#  Gang Song (Google Summer of Code 2017 intern, Shanghai Jiao Tong University)
 -#  Wenyao Gan (Shanghai Jiao Tong University)
 -#  Mohammad Reza Haghighat (Intel Corporation)
 -#  Ningxin Hu (Intel Corporation)

--- a/doc/js_tutorials/js_setup/js_setup/js_setup.markdown
+++ b/doc/js_tutorials/js_setup/js_setup/js_setup.markdown
@@ -1,11 +1,11 @@
-Install OpenCV-JavaScript {#tutorial_js_setup}
+Build OpenCV.js {#tutorial_js_setup}
 ===============================
 
 
 Installing Emscripten
 -----------------------------
 
-[Emscripten](https://github.com/kripken/emscripten) is an LLVM-to-JavaScript compiler. We will use Emscripten to build OpenCV-JavaScript.
+[Emscripten](https://github.com/kripken/emscripten) is an LLVM-to-JavaScript compiler. We will use Emscripten to build OpenCV.js.
 
 To Install emscripten, you can follow instructions of [Emscripten SDK](https://kripken.github.io/emscripten-site/docs/getting_started/downloads.html).
 
@@ -49,7 +49,7 @@ git clone https://github.com/opencv/opencv.git
 @note
 You may need to install `git` for your development environment.
 
-Building OpenCV-JavaScript from Source Using CMake
+Building OpenCV.js from Source Using CMake
 ---------------------------------------
 
 -#  Create a temporary directory, which we denote as \<cmake_build_dir\>, where you want to put
@@ -63,7 +63,7 @@ Building OpenCV-JavaScript from Source Using CMake
     cd build_js
     @endcode
 -#  Configuring. Run cmake [\<some optional parameters\>] \<path to the OpenCV source directory\>
-	To build OpenCV-JavaScript, you need to append `-D CMAKE_TOOLCHAIN_FILE=${EMSCRIPTEN}/cmake/Modules/Platform/Emscripten.cmake`.
+	To build OpenCV.js, you need to append `-D CMAKE_TOOLCHAIN_FILE=${EMSCRIPTEN}/cmake/Modules/Platform/Emscripten.cmake`.
 
     For example
     @code{.bash}

--- a/doc/js_tutorials/js_setup/js_table_of_contents_setup.markdown
+++ b/doc/js_tutorials/js_setup/js_table_of_contents_setup.markdown
@@ -1,15 +1,14 @@
-Introduction to OpenCV-JavaScript {#tutorial_js_table_of_contents_setup}
+Introduction to OpenCV.js {#tutorial_js_table_of_contents_setup}
 ======================
 
 -   @subpage tutorial_js_intro
 
-    Introduction of OpenCV-JavaScript and Tutorials
-
--   @subpage tutorial_js_setup
-
-    Build and
-    Install OpenCV-JavaScript
+    Introduction of OpenCV.js and Tutorials
 
 -   @subpage tutorial_js_usage
 
-    Use OpenCV-JavaScript
+    Get started with OpenCV.js
+
+-   @subpage tutorial_js_setup
+
+    Build OpenCV.js from source

--- a/doc/js_tutorials/js_setup/js_usage/js_usage.markdown
+++ b/doc/js_tutorials/js_setup/js_usage/js_usage.markdown
@@ -1,14 +1,15 @@
-Using OpenCV-JavaScript {#tutorial_js_usage}
+Using OpenCV.js {#tutorial_js_usage}
 ===============================
-
-@note We assume that you have successfully installed or built `opencv.js` in your workstation.
 
 Steps
 -----
 
+In this tutorial, you will see how to include and start to use `opencv.js` inside a web page.
+
 ### Create a web page uploading and displaying image
 
 First, let's create a simple web page which is able to upload and display an image.
+
 @code{.js}
 <!DOCTYPE html>
 <html>
@@ -32,49 +33,20 @@ inputElement.addEventListener("change", (e) => {
 </html>
 @endcode
 
-You can copy above content and save to a local index.html file. To run it, please open it by the web browser.
+You can copy above content and save to a local index.html file. To run it, just open it by the web browser.
 
 @note It is a better practice that is hosting the index.html by a local web server.
 
-An embedded version is shown below. You can upload an image from filesystem to display on the web page.
+### Include `opencv.js`
 
-- - -
+To include `opencv.js`, you need to set the URL of `opencv.js` to `src` attribute of of \<script\> tag.
 
-\htmlonly
-<!DOCTYPE html>
-<html>
-<body>
-
-<h1>My First OpenCV.js Web Page</h1>
-
-<div>
-    <img id='srcImage'></img>
-</div>
-<input type='file' id='fileInput' accept='image/gif, image/jpeg, image/png'/>
-
-<script>
-let imgElement = document.getElementById('srcImage')
-let inputElement = document.getElementById('fileInput');
-inputElement.addEventListener("change", (e) => {
-  imgElement.src = URL.createObjectURL(e.target.files[0]);
-}, false);
-</script>
-</body>
-</html>
-\endhtmlonly
-
-- - -
-
-### Add `opencv.js` and use cv.Mat
-
-Now you need to load the `opencv.js` library by \<script\> tag.
+@note For this tutorial, we host `opencv.js` at same folder of index.html.
 
 Example for synchronous loading.
 @code{.js}
 <script src="opencv.js"></script>
 @endcode
-
-@note `opencv.js` should be in the same folder of `index.html`.
 
 You may want to load `opencv.js` asynchronously by `async` attribute in \<script\> tag. To be notified by `opencv.js` is ready, you can
 register a callback to `Module['onRuntimeInitialized']`. Please refer to [Emscripten FAQ](https://kripken.github.io/emscripten-site/docs/getting_started/FAQ.html#how-can-i-tell-when-the-page-is-fully-loaded-and-it-is-safe-to-call-compiled-functions) for details.
@@ -88,6 +60,8 @@ var Module = {
 </script>
 <script src="opencv.js" async></script>
 @endcode
+
+### Use `opencv.js`
 
 Once `opencv.js` is ready, you can access OpenCV objects and functions through `cv` object.
 
@@ -167,9 +141,9 @@ An embedded version is shown below. You can try it.
 <p id='status'>OpenCV.js is loading.</p>
 
 <div>
-    <img id='srcImage1'></img>
+    <img id='srcImage'></img>
 </div>
-<input type='file' id='fileInput1' accept='image/gif, image/jpeg, image/png'/>
+<input type='file' id='fileInput' accept='image/gif, image/jpeg, image/png'/>
 <div>
     <canvas id='outputCanvas'></canvas>
 <div>
@@ -192,13 +166,13 @@ function imread(image) {
     return cv.matFromArray(imgData, cv.CV_8UC4);
 }
 
-let imgElement1 = document.getElementById('srcImage1')
-let inputElement1 = document.getElementById('fileInput1');
-inputElement1.addEventListener("change", (e) => {
-  imgElement1.src = URL.createObjectURL(e.target.files[0]);
+let imgElement = document.getElementById('srcImage')
+let inputElement = document.getElementById('fileInput');
+inputElement.addEventListener("change", (e) => {
+  imgElement.src = URL.createObjectURL(e.target.files[0]);
 }, false);
-imgElement1.onload = function() {
-  let mat = imread(imgElement1);
+imgElement.onload = function() {
+  let mat = imread(imgElement);
   cv.imshow('outputCanvas', mat);
 }
 </script>

--- a/doc/js_tutorials/js_tutorials.markdown
+++ b/doc/js_tutorials/js_tutorials.markdown
@@ -1,9 +1,9 @@
-OpenCV-JavaScript Tutorials {#tutorial_js_root}
+OpenCV.js Tutorials {#tutorial_js_root}
 =======================
 
 -   @subpage tutorial_js_table_of_contents_setup
 
-    Learn how to build OpenCV-JavaScript on your computer!
+    Learn how to use OpenCV.js inside your web pages!
 
 -   @subpage tutorial_js_table_of_contents_gui
 

--- a/doc/js_tutorials/js_video/js_bg_subtraction/js_bg_subtraction.markdown
+++ b/doc/js_tutorials/js_video/js_bg_subtraction/js_bg_subtraction.markdown
@@ -91,7 +91,7 @@ bgsLoopIndex = setInterval(
 <div id="contentarea">
     <button id="bgsStartup" disabled="true" onclick="bgsStartup()">try it</button>
     <button id="bgsStop" disabled="true" onclick="bgsStopVideo()">stop</button><br>
-    <video id="bgsVideo" src="box.mp4" width="320">Your browser does not support the video tag.</video>
+    <video id="bgsVideo" src="box.mp4" width="320" muted>Your browser does not support the video tag.</video>
     <canvas id="bgsCanvasOutput"></canvas>
 </div>
 <script src="adapter.js"></script>

--- a/doc/js_tutorials/js_video/js_lucas_kanade/js_lucas_kanade.markdown
+++ b/doc/js_tutorials/js_video/js_lucas_kanade/js_lucas_kanade.markdown
@@ -192,7 +192,7 @@ lkofLoopIndex = setInterval(
 <div id="contentarea">
     <button id="lkofStartup" disabled="true" onclick="lkofStartup()">try it</button>
     <button id="lkofStop" disabled="true" onclick="lkofStopVideo()">stop</button><br>
-    <video id="lkofVideo" src="box.mp4" width="640" hidden>Your browser does not support the video tag.</video>
+    <video id="lkofVideo" src="box.mp4" width="640" muted hidden>Your browser does not support the video tag.</video>
     <canvas id="lkofCanvasOutput"></canvas>
 </div>
 <script src="adapter.js"></script>
@@ -384,7 +384,7 @@ dofLoopIndex = setInterval(
 <div id="contentarea">
     <button id="dofStartup" disabled="true" onclick="dofStartup()">try it</button>
     <button id="dofStop" disabled="true" onclick="dofStopVideo()">stop</button><br>
-    <video id="dofVideo" src="box.mp4" width="320">Your browser does not support the video tag.</video>
+    <video id="dofVideo" src="box.mp4" width="320" muted>Your browser does not support the video tag.</video>
     <canvas id="dofCanvasOutput"></canvas>
 </div>
 <script>

--- a/doc/js_tutorials/js_video/js_meanshift/js_meanshift.markdown
+++ b/doc/js_tutorials/js_video/js_meanshift/js_meanshift.markdown
@@ -126,7 +126,7 @@ msLoopIndex = setInterval(
 <div id="contentarea">
     <button id="msStartup" disabled="true" onclick="msStartup()">try it</button>
     <button id="msStop" disabled="true" onclick="msStopVideo()">stop</button><br>
-    <video id="msVideo" src="cup.mp4" width="640" hidden>Your browser does not support the video tag.</video>
+    <video id="msVideo" src="cup.mp4" width="640" muted hidden>Your browser does not support the video tag.</video>
     <canvas id="msCanvasOutput"></canvas>
 </div>
 <script src="adapter.js"></script>
@@ -321,7 +321,7 @@ csLoopIndex = setInterval(
 <div id="contentarea">
     <button id="csStartup" disabled="true" onclick="csStartup()">try it</button>
     <button id="csStop" disabled="true" onclick="csStopVideo()">stop</button><br>
-    <video id="csVideo" src="cup.mp4" width="640" hidden>Your browser does not support the video tag.</video>
+    <video id="csVideo" src="cup.mp4" width="640" muted hidden>Your browser does not support the video tag.</video>
     <canvas id="csCanvasOutput"></canvas>
 </div>
 <script>


### PR DESCRIPTION
Changes include:
- Use OpenCV.js name instead of OpenCV-JavaScript
- Put using OpenCV.js ahead of build OpenCV.js
- Refine usage and introduction page
- Muted the video in tutorials

