### PR TITLE
[opencv.js benchmark] add performance tests building option

### DIFF
--- a/modules/js/CMakeLists.txt
+++ b/modules/js/CMakeLists.txt
@@ -154,15 +154,12 @@ set(perf_dir ${CMAKE_CURRENT_SOURCE_DIR}/perf)
 
 set(opencv_perf_js_file_deps "")
 
-# message(STATUS "${opencv_perf_js_bin_dir}")
-
 # make sure the build directory exists
 file(MAKE_DIRECTORY "${opencv_perf_js_bin_dir}")
 
 # gather and copy specific files for js perf
 file(GLOB_RECURSE perf_files RELATIVE "${perf_dir}" "${perf_dir}/*")
 foreach(f ${perf_files})
-  # message(STATUS "copy ${perf_dir}/${f} ${opencv_perf_js_bin_dir}/${f}")
   add_custom_command(OUTPUT "${opencv_perf_js_bin_dir}/${f}"
                      COMMAND ${CMAKE_COMMAND} -E copy_if_different "${perf_dir}/${f}" "${opencv_perf_js_bin_dir}/${f}"
                      DEPENDS "${perf_dir}/${f}"

--- a/modules/js/CMakeLists.txt
+++ b/modules/js/CMakeLists.txt
@@ -147,3 +147,29 @@ list(APPEND opencv_test_js_file_deps "${test_data_path}" "${opencv_test_js_bin_d
 
 add_custom_target(${PROJECT_NAME}_test ALL
                   DEPENDS ${OCV_JS_PATH} ${opencv_test_js_file_deps})
+
+# perf
+set(opencv_perf_js_bin_dir "${EXECUTABLE_OUTPUT_PATH}/perf")
+set(perf_dir ${CMAKE_CURRENT_SOURCE_DIR}/perf)
+
+set(opencv_perf_js_file_deps "")
+
+# message(STATUS "${opencv_perf_js_bin_dir}")
+
+# make sure the build directory exists
+file(MAKE_DIRECTORY "${opencv_perf_js_bin_dir}")
+
+# gather and copy specific files for js perf
+file(GLOB_RECURSE perf_files RELATIVE "${perf_dir}" "${perf_dir}/*")
+foreach(f ${perf_files})
+  # message(STATUS "copy ${perf_dir}/${f} ${opencv_perf_js_bin_dir}/${f}")
+  add_custom_command(OUTPUT "${opencv_perf_js_bin_dir}/${f}"
+                     COMMAND ${CMAKE_COMMAND} -E copy_if_different "${perf_dir}/${f}" "${opencv_perf_js_bin_dir}/${f}"
+                     DEPENDS "${perf_dir}/${f}"
+                     COMMENT "Copying ${f}"
+                    )
+  list(APPEND opencv_perf_js_file_deps "${perf_dir}/${f}" "${opencv_perf_js_bin_dir}/${f}")
+endforeach()
+
+add_custom_target(${PROJECT_NAME}_perf ALL
+                  DEPENDS ${OCV_JS_PATH} ${opencv_perf_js_file_deps})

--- a/platforms/js/build_js.py
+++ b/platforms/js/build_js.py
@@ -180,6 +180,9 @@ class Builder:
     def build_test(self):
         execute(["make", "-j", str(multiprocessing.cpu_count()), "opencv_js_test"])
 
+    def build_perf(self):
+        execute(["make", "-j", str(multiprocessing.cpu_count()), "opencv_js_perf"])
+
     def build_doc(self):
         execute(["make", "-j", str(multiprocessing.cpu_count()), "doxygen"])
 
@@ -200,6 +203,7 @@ if __name__ == "__main__":
     parser.add_argument('--disable_wasm', action="store_true", help="Build OpenCV.js in Asm.js format")
     parser.add_argument('--threads', action="store_true", help="Build OpenCV.js with threads optimization")
     parser.add_argument('--build_test', action="store_true", help="Build tests")
+    parser.add_argument('--build_perf', action="store_true", help="Build performance tests")
     parser.add_argument('--build_doc', action="store_true", help="Build tutorials")
     parser.add_argument('--clean_build_dir', action="store_true", help="Clean build dir")
     parser.add_argument('--skip_config', action="store_true", help="Skip cmake config")
@@ -248,6 +252,12 @@ if __name__ == "__main__":
         log.info("===== Building OpenCV.js tests")
         log.info("=====")
         builder.build_test()
+    
+    if args.build_perf:
+        log.info("=====")
+        log.info("===== Building OpenCV.js performance tests")
+        log.info("=====")
+        builder.build_perf()
 
     if args.build_doc:
         log.info("=====")
@@ -267,6 +277,11 @@ if __name__ == "__main__":
     if args.build_test:
         opencvjs_test_path = os.path.join(builder.build_dir, "bin", "tests.html")
         if check_file(opencvjs_test_path):
+            log.info("OpenCV.js tests location: %s", opencvjs_test_path)
+
+    if args.build_perf:
+        opencvjs_perf_path = os.path.join(builder.build_dir, "bin", "perf", "base.js")
+        if check_file(opencvjs_perf_path):
             log.info("OpenCV.js tests location: %s", opencvjs_test_path)
 
     if args.build_doc:


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->
fix #266 

### This pullrequest changes
Add performance tests building option `--build_perf`. If building with this flag, the `/perf` folder will be copied to `bin/perf`.

<!-- Please describe what your pullrequest is changing -->
