### PR TITLE
Fix filter issue of perf tests

### DIFF
--- a/modules/js/perf/base.js
+++ b/modules/js/perf/base.js
@@ -2,21 +2,25 @@ if (typeof window === 'undefined') {
   var cv = require("../opencv");
 }
 
-function createCvSize() {
-  var cvSize = {
-    szODD: new cv.Size(127, 61),
-    szQVGA: new cv.Size(320, 240),
-    szVGA: new cv.Size(640, 480),
-    szqHD: new cv.Size(960, 540),
-    sz720p: new cv.Size(1280, 720),
-    sz1080p: new cv.Size(1920, 1080),
-    sz130x60: new cv.Size(130, 60),
-    sz213x120: new cv.Size(120 * 1280 / 720, 120),
+let gCvSize;
+
+function getCvSize() {
+  if (gCvSize === undefined) {
+    gCvSize = {
+      szODD: new cv.Size(127, 61),
+      szQVGA: new cv.Size(320, 240),
+      szVGA: new cv.Size(640, 480),
+      szqHD: new cv.Size(960, 540),
+      sz720p: new cv.Size(1280, 720),
+      sz1080p: new cv.Size(1920, 1080),
+      sz130x60: new cv.Size(130, 60),
+      sz213x120: new cv.Size(120 * 1280 / 720, 120),
+    };
   }
 
-  return cvSize
+  return gCvSize;
 }
 
 if (typeof window === 'undefined') {
-  exports.createCvSize = createCvSize;
+  exports.getCvSize = getCvSize;
 }

--- a/modules/js/perf/perf_helpfunc.js
+++ b/modules/js/perf/perf_helpfunc.js
@@ -19,7 +19,7 @@ var fillGradient = function(cv, img, delta=5) {
 var cvtStr2cvSize = function(strSize) {
   let size;
 
-  cvSize = createCvSize()
+  let cvSize = getCvSize();
   switch(strSize) {
     case "127,61": size = cvSize.szODD;break;
     case '320,240': size = cvSize.szQVGA;break;

--- a/modules/js/perf/perf_imgproc/perf_cvtcolor.js
+++ b/modules/js/perf/perf_imgproc/perf_cvtcolor.js
@@ -18,12 +18,12 @@ function perf() {
     global.cv = cv;
     global.combine = HelpFunc.combine;
     global.cvtStr2cvSize = HelpFunc.cvtStr2cvSize;
-    global.cvSize = Base.createCvSize();
+    global.cvSize = Base.getCvSize();
   } else {
     runButton.removeAttribute('disabled');
     runButton.setAttribute('class', 'btn btn-primary');
     runButton.innerHTML = 'Run';
-    cvSize = createCvSize();
+    cvSize = getCvSize();
   }
   let totalCaseNum, currentCaseId;
 

--- a/modules/js/perf/perf_imgproc/perf_resize.js
+++ b/modules/js/perf/perf_imgproc/perf_resize.js
@@ -18,12 +18,12 @@ function perf() {
     global.cv = cv;
     global.combine = HelpFunc.combine;
     global.cvtStr2cvSize = HelpFunc.cvtStr2cvSize;
-    global.cvSize = Base.createCvSize();
+    global.cvSize = Base.getCvSize();
   } else {
     runButton.removeAttribute('disabled');
     runButton.setAttribute('class', 'btn btn-primary');
     runButton.innerHTML = 'Run';
-    cvSize = createCvSize();
+    cvSize = getCvSize();
   }
   let totalCaseNum, currentCaseId;
 

--- a/modules/js/perf/perf_imgproc/perf_threshold.js
+++ b/modules/js/perf/perf_imgproc/perf_threshold.js
@@ -18,12 +18,12 @@ function perf() {
     global.cv = cv;
     global.combine = HelpFunc.combine;
     global.cvtStr2cvSize = HelpFunc.cvtStr2cvSize;
-    global.cvSize = Base.createCvSize();
+    global.cvSize = Base.getCvSize();
   } else {
     runButton.removeAttribute('disabled');
     runButton.setAttribute('class', 'btn btn-primary');
     runButton.innerHTML = 'Run';
-    cvSize = createCvSize();
+    cvSize = getCvSize();
   }
   let totalCaseNum, currentCaseId;
 


### PR DESCRIPTION
@lionkunonly , this PR fixes the issue of #339 that the test filter doesn't work, e.g. "(1920x1080, CV_8UC1, THRESH_BINARY)" for perf_cvtcolor.html.

The root cause is the cvSize comparison is to compare object not the values of it. So we need to make sure they are same objects. I use a singleton gCvSize to solve it. Please take a look.